### PR TITLE
Add aggregate collection name to ressource

### DIFF
--- a/packages/datadog-plugin-mongodb-core/src/index.js
+++ b/packages/datadog-plugin-mongodb-core/src/index.js
@@ -10,7 +10,7 @@ class MongodbCorePlugin extends DatabasePlugin {
   static get peerServicePrecursors () { return [] }
   start ({ ns, ops, options = {}, name }) {
     const query = getQuery(ops)
-    const resource = truncate(getResource(this, ns, query, name))
+    const resource = truncate(getResource(this, ns, query, name, ops.aggregate))
     this.startSpan(this.operationName(), {
       service: this.serviceName({ pluginConfig: this.config }),
       resource,
@@ -47,8 +47,9 @@ function getQuery (cmd) {
   if (cmd.pipeline) return sanitizeBigInt(limitDepth(cmd.pipeline))
 }
 
-function getResource (plugin, ns, query, operationName) {
-  const parts = [operationName, ns]
+function getResource (plugin, ns, query, operationName, aggregateCollection) {
+  const appendedNs = aggregateCollection ? `${ns}.${aggregateCollection}` : ns
+  const parts = [operationName, appendedNs]
 
   if (plugin.config.queryInResourceName && query) {
     parts.push(query)

--- a/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
@@ -234,6 +234,25 @@ describe('Plugin', () => {
             }).toArray()
           })
 
+          it('should append the collection name to ressource for aggregate queries', done => {
+            agent
+              .use(traces => {
+                const span = traces[0][0]
+                const resource = `aggregate test.$cmd.${collectionName}`
+                const query = '[{"$match":{"_id":"1234"}},{"$project":{"_id":1}}]'
+
+                expect(span).to.have.property('resource', resource)
+                expect(span.meta).to.have.property('mongodb.query', query)
+              })
+              .then(done)
+              .catch(done)
+
+            collection.aggregate([
+              { $match: { _id: '1234' } },
+              { $project: { _id: 1 } }
+            ]).toArray()
+          })
+
           it('should use the toJSON method of objects if it exists', done => {
             const id = '123456781234567812345678'
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Append aggregation collection name to the namespace when getting the ressource for mongodb queries.

### Motivation
<!-- What inspired you to submit this pull request? -->

I want to know which collection was used with my aggregation queries.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

